### PR TITLE
Add gamedata for mod NeotokyoSource

### DIFF
--- a/addons/sourcemod/gamedata/firebulletsfix.games.txt
+++ b/addons/sourcemod/gamedata/firebulletsfix.games.txt
@@ -103,4 +103,15 @@
 			}
 		}
 	}
+
+	"NeotokyoSource"
+	{
+		"Offsets"
+		{
+			"Weapon_ShootPosition"
+			{
+				"windows"	"221"
+			}
+		}
+	}
 }


### PR DESCRIPTION
Fix #10 

Adding only for Windows, because it's the only server binary platform available for this mod.